### PR TITLE
Inverse the behavior of humidity check: switch on if humidity is too high

### DIFF
--- a/src/main/scala/io/tardieu/netwemo/checkers/HumidityChecker.scala
+++ b/src/main/scala/io/tardieu/netwemo/checkers/HumidityChecker.scala
@@ -38,7 +38,8 @@ class HumidityChecker private (val wemoConnector: WemoConnector, val netatmoConn
 
   override def computeDesiredState(value: Float): Option[Boolean] = {
     inService(startTime, stopTime) match {
-      case true => computeState(value, lowThreshold, highThreshold)
+      case true => computeState(value, lowThreshold, highThreshold).map(!_) // We want to switch on the
+        // deshumidifier if the value is too high
       case false => Some(false)
     }
   }


### PR DESCRIPTION
The behavior of the humidity check is the opposite of the temperature one:
we want to switch on the humidity device if the humidity is too high.