### PR TITLE
Use Float instead of Long in the Measure object

### DIFF
--- a/src/main/scala/io/tardieu/netwemo/connectors/NetatmoConnector.scala
+++ b/src/main/scala/io/tardieu/netwemo/connectors/NetatmoConnector.scala
@@ -25,7 +25,7 @@ object Metric extends Enumeration {
 }
 
 final case class Token(access_token: String, expires_in: Long)
-final case class Measure(value: Seq[Seq[Long]])
+final case class Measure(value: Seq[Seq[Float]])
 final case class NetatmoResponse(status: String, body: Seq[Measure], time_exec: Float)
 
 trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {


### PR DESCRIPTION
The temperature sent by Netatmo is a Float and should be treated as such.