### PR TITLE
Use seconds instead of nanos for duration

### DIFF
--- a/src/main/scala/io/tardieu/netwemo/CheckScheduler.scala
+++ b/src/main/scala/io/tardieu/netwemo/CheckScheduler.scala
@@ -25,8 +25,8 @@ class CheckScheduler(wemoConnector: WemoConnector,
 
   private[this] val conf = ConfigFactory.load().getConfig("scheduler")
 
-  private[this] val checkInterval =
-    FiniteDuration(conf.getDuration("checkInterval").getNano, TimeUnit.NANOSECONDS)
+  private[netwemo] val checkInterval =
+    FiniteDuration(conf.getDuration("checkInterval").getSeconds, TimeUnit.SECONDS)
 
   private[netwemo] var tempSchedule: Option[Cancellable] = None
   private[netwemo] var humiditySchedule: Option[Cancellable] = None

--- a/src/test/scala/io/tardieu/netwemo/CheckSchedulerSpec.scala
+++ b/src/test/scala/io/tardieu/netwemo/CheckSchedulerSpec.scala
@@ -29,7 +29,11 @@ class CheckSchedulerSpec extends FlatSpec with Matchers with MockitoSugar with B
   }
 
   "The CheckScheduler" should
-  "correctly create a temperature schedule" in new Fixtures {
+  "correctly parse the checkInterval" in new Fixtures {
+    checkScheduler.checkInterval shouldBe 1.second
+  }
+
+  it should "correctly create a temperature schedule" in new Fixtures {
     checkScheduler.tempSchedule shouldBe empty
     checkScheduler.scheduleOrReplaceTemperature(1.hour)
     checkScheduler.tempSchedule shouldBe defined


### PR DESCRIPTION
Turns out the `getNano` method on the `Duration` object only gives
the nano part of the duration which is stored in seconds and in nanos.
So if the duration is 10 minutes the `getNano` method will return 0.